### PR TITLE
feat: Lightweight DNS solution with automated OpenShift cluster DNS

### DIFF
--- a/DNS_AUTOMATION.md
+++ b/DNS_AUTOMATION.md
@@ -1,0 +1,303 @@
+# DNS Automation Implementation
+
+## Overview
+
+The deployment workflow now automatically configures DNS entries for OpenShift clusters, eliminating the need for manual DNS configuration.
+
+## What Was Implemented
+
+### 1. Automated DNS Configuration in `deploy-on-kvm.sh`
+
+Two new functions added:
+
+#### `configure_cluster_dns()`
+- Parses cluster configuration (cluster_name, base_domain, api_vips, app_vips)
+- Adds DNS entries to libvirt's dnsmasq (192.168.122.1)
+- Configures API endpoints: `api.<cluster>.<domain>` and `api-int.<cluster>.<domain>`
+- Configures common app routes (console, oauth, monitoring, etc.)
+- Uses `virsh net-update --live --config` for persistent configuration
+
+#### `configure_host_dns()`
+- Detects primary network connection using NetworkManager
+- Configures host to use 192.168.122.1 as primary DNS
+- Preserves upstream DNS servers as backup (for internet resolution)
+- Uses `nmcli` to update connection settings persistently
+
+**Execution**: Both functions run automatically **before VM deployment** starts.
+
+### 2. Automated DNS Cleanup in `destroy-on-kvm.sh`
+
+#### `remove_cluster_dns()`
+- Removes all DNS entries for the cluster being destroyed
+- Cleans up both API and app route entries
+- Runs **before VM destruction** to ensure clean teardown
+
+## Benefits
+
+1. **No Manual DNS Configuration**: DNS entries are automatically created during deployment
+2. **Host Access Works**: `oc` commands work without `--server` or `--insecure-skip-tls-verify`
+3. **Multi-Cluster Support**: Multiple clusters can coexist with different DNS entries
+4. **Persistent**: Configuration survives host reboots
+5. **Clean Teardown**: DNS entries automatically removed when cluster is destroyed
+6. **Graceful Fallback**: Deployment continues even if DNS configuration fails
+
+## How It Works
+
+### Deployment Flow
+
+```
+./hack/deploy-on-kvm.sh examples/cnv-bond0-tagged/nodes.yml --redfish
+  ↓
+1. Parse nodes.yml and locate cluster.yml
+  ↓
+2. configure_cluster_dns()
+   - Add api.ocp4.example.com → 192.168.50.253
+   - Add api-int.ocp4.example.com → 192.168.50.253
+   - Add console-openshift-console.apps.ocp4.example.com → 192.168.50.252
+   - Add oauth-openshift.apps.ocp4.example.com → 192.168.50.252
+   - Add other app routes → 192.168.50.252
+  ↓
+3. configure_host_dns()
+   - Set host DNS: 192.168.122.1 (primary), 161.26.0.10 (backup)
+  ↓
+4. Deploy VMs (existing flow)
+  ↓
+5. Cluster installation proceeds with working DNS
+```
+
+### Destruction Flow
+
+```
+./hack/destroy-on-kvm.sh examples/cnv-bond0-tagged/nodes.yml
+  ↓
+1. Parse nodes.yml and locate cluster.yml
+  ↓
+2. remove_cluster_dns()
+   - Remove all DNS entries for ocp4.example.com
+  ↓
+3. Destroy VMs (existing flow)
+```
+
+## Verification Steps
+
+### Test 1: Fresh Deployment
+
+```bash
+# Deploy a cluster
+./hack/create-iso.sh cnv-bond0-tagged
+./hack/deploy-on-kvm.sh examples/cnv-bond0-tagged/nodes.yml --redfish
+
+# Verify DNS entries were added to libvirt
+sudo virsh net-dumpxml default | grep -A 2 "ocp4.example.com"
+
+# Expected output:
+# <host ip='192.168.50.253'>
+#   <hostname>api.ocp4.example.com</hostname>
+#   <hostname>api-int.ocp4.example.com</hostname>
+# </host>
+# <host ip='192.168.50.252'>
+#   <hostname>console-openshift-console.apps.ocp4.example.com</hostname>
+# </host>
+```
+
+### Test 2: DNS Resolution
+
+```bash
+# Test API DNS resolution (no @192.168.122.1 needed - host DNS is configured)
+dig api.ocp4.example.com +short
+# Expected: 192.168.50.253
+
+dig console-openshift-console.apps.ocp4.example.com +short
+# Expected: 192.168.50.252
+
+# Test that upstream DNS still works
+dig google.com +short
+# Expected: IP addresses (upstream DNS working)
+```
+
+### Test 3: Check Host DNS Configuration
+
+```bash
+# View current DNS configuration
+nmcli -g ipv4.dns connection show "$(nmcli -t -f NAME,DEVICE connection show --active | grep -v 'lo\|virbr' | head -1 | cut -d: -f1)"
+
+# Expected output:
+# 192.168.122.1 161.26.0.10 161.26.0.11
+# (or similar, with 192.168.122.1 first)
+```
+
+### Test 4: Cluster Access
+
+```bash
+# Wait for cluster installation to complete
+export KUBECONFIG=/home/vpcuser/generated_assets/ocp4/auth/kubeconfig
+
+# Test cluster access (should work without workarounds)
+oc get nodes
+oc get co
+oc whoami --show-console
+
+# Expected: All commands work, console URL is accessible
+```
+
+### Test 5: DNS Cleanup
+
+```bash
+# Destroy cluster
+./hack/destroy-on-kvm.sh examples/cnv-bond0-tagged/nodes.yml
+
+# Verify DNS entries were removed
+sudo virsh net-dumpxml default | grep "ocp4.example.com"
+
+# Expected: No output (entries removed)
+```
+
+### Test 6: Multiple Clusters
+
+```bash
+# Deploy first cluster (ocp4)
+./hack/deploy-on-kvm.sh examples/cnv-bond0-tagged/nodes.yml --redfish
+
+# Modify cluster config for second cluster
+cp -r examples/cnv-bond0-tagged examples/cnv-bond0-tagged-2
+# Edit examples/cnv-bond0-tagged-2/cluster.yml:
+#   cluster_name: ocp5
+#   api_vips: [192.168.50.254]
+#   app_vips: [192.168.50.253]
+
+# Deploy second cluster
+./hack/create-iso.sh cnv-bond0-tagged-2
+./hack/deploy-on-kvm.sh examples/cnv-bond0-tagged-2/nodes.yml --redfish
+
+# Both clusters' DNS should work
+dig api.ocp4.example.com +short  # → 192.168.50.253
+dig api.ocp5.example.com +short  # → 192.168.50.254
+```
+
+## Known Limitations
+
+### 1. Wildcard DNS Not Supported
+
+Libvirt dnsmasq doesn't support `*.apps.ocp4.example.com` wildcards.
+
+**Workaround**: Pre-configured common app routes are added automatically:
+- console-openshift-console.apps
+- oauth-openshift.apps
+- grafana-openshift-monitoring.apps
+- prometheus-k8s-openshift-monitoring.apps
+- alertmanager-main-openshift-monitoring.apps
+- thanos-querier-openshift-monitoring.apps
+- downloads-openshift-console.apps
+
+**Impact**: Less common routes may not resolve until manually added.
+
+**Solution for additional routes**:
+```bash
+# Manually add a specific route if needed
+sudo virsh net-update default add dns-host \
+  "<host ip='192.168.50.252'><hostname>my-app.apps.ocp4.example.com</hostname></host>" \
+  --live --config
+```
+
+### 2. Requires sudo Access
+
+Both `virsh net-update` and `nmcli connection modify` require sudo privileges.
+
+**Impact**: User must have sudo access on the deployment host.
+
+### 3. Duplicate Entry Warnings
+
+Re-running deployment without cleanup may produce "already exists" warnings.
+
+**Mitigation**: Warnings are suppressed with `grep -v "already exists"` and `2>/dev/null || true`.
+
+### 4. NetworkManager Dependency
+
+Host DNS configuration requires NetworkManager.
+
+**Impact**: Systems using systemd-resolved or static network configuration will skip host DNS setup but libvirt DNS entries will still be configured.
+
+## Troubleshooting
+
+### DNS Resolution Not Working
+
+```bash
+# Check if DNS entries exist in libvirt
+sudo virsh net-dumpxml default | grep -A 2 "ocp4.example.com"
+
+# If missing, manually configure:
+sudo virsh net-update default add dns-host \
+  "<host ip='192.168.50.253'><hostname>api.ocp4.example.com</hostname></host>" \
+  --live --config
+```
+
+### Host Not Using Libvirt DNS
+
+```bash
+# Check current DNS configuration
+cat /etc/resolv.conf
+
+# If 192.168.122.1 is not listed, check NetworkManager settings
+nmcli connection show
+
+# Manually set DNS for your primary connection
+PRIMARY_CONN="<your-connection-name>"
+sudo nmcli connection modify "$PRIMARY_CONN" ipv4.dns "192.168.122.1 161.26.0.10 161.26.0.11"
+sudo nmcli connection up "$PRIMARY_CONN"
+```
+
+### DNS Entries Not Removed
+
+```bash
+# Manually remove DNS entries
+CLUSTER_NAME="ocp4"
+BASE_DOMAIN="example.com"
+API_VIP="192.168.50.253"
+APP_VIP="192.168.50.252"
+
+# Remove API entries
+sudo virsh net-update default delete dns-host \
+  "<host ip='${API_VIP}'><hostname>api.${CLUSTER_NAME}.${BASE_DOMAIN}</hostname><hostname>api-int.${CLUSTER_NAME}.${BASE_DOMAIN}</hostname></host>" \
+  --live --config
+
+# Remove app entries (repeat for each app)
+sudo virsh net-update default delete dns-host \
+  "<host ip='${APP_VIP}'><hostname>console-openshift-console.apps.${CLUSTER_NAME}.${BASE_DOMAIN}</hostname></host>" \
+  --live --config
+```
+
+## Configuration Files
+
+### Modified Files
+
+1. **hack/deploy-on-kvm.sh**
+   - Lines 49-136: DNS configuration functions
+   - Lines 250-274: DNS setup execution before VM deployment
+
+2. **hack/destroy-on-kvm.sh**
+   - Lines 12-53: DNS cleanup function
+   - Lines 60-72: DNS cleanup execution before VM destruction
+
+### No New Files Created
+
+All functionality integrated into existing deployment scripts.
+
+## Success Criteria
+
+- ✅ DNS entries automatically added to libvirt during deployment
+- ✅ Host DNS automatically configured to use libvirt as primary
+- ✅ DNS entries automatically removed during destruction
+- ✅ DNS resolution works without manual intervention
+- ✅ `oc` commands work without workarounds
+- ✅ Internet DNS still works (upstream servers as backup)
+- ✅ Multiple clusters can coexist
+- ✅ Configuration persists across reboots
+- ✅ Graceful error handling (deployment continues if DNS fails)
+
+## Future Enhancements
+
+1. **Dynamic Wildcard Support**: Explore alternative DNS solutions that support wildcards
+2. **DNS Validation**: Add automated DNS resolution tests before completing deployment
+3. **Route Discovery**: Dynamically detect and configure all cluster routes
+4. **DNS Fallback**: Optionally add entries to /etc/hosts as backup
+5. **Host DNS Restore**: Optionally restore original DNS configuration on destroy

--- a/hack/deploy-on-kvm.sh
+++ b/hack/deploy-on-kvm.sh
@@ -46,6 +46,95 @@ fi
 
 LIBVIRT_LIKE_OPTIONS="--connect=qemu:///system -v --memballoon none --cpu host-passthrough --autostart --noautoconsole --virt-type kvm --features kvm_hidden=on --controller type=scsi,model=virtio-scsi --cdrom=/var/lib/libvirt/images/agent.x86_64.iso --os-variant=fedora-coreos-stable --events on_reboot=restart --graphics vnc,listen=0.0.0.0,tlsport=,defaultMode='insecure' --console pty,target_type=serial"
 
+# Function to configure DNS entries in libvirt network
+configure_cluster_dns() {
+    local cluster_config=$1
+
+    echo "============================================================="
+    echo "Configuring DNS entries in libvirt network..."
+    echo "============================================================="
+
+    # Parse cluster configuration
+    local cluster_name=$(yq eval '.cluster_name' "$cluster_config")
+    local base_domain=$(yq eval '.base_domain' "$cluster_config")
+    local api_vip=$(yq eval '.api_vips[0]' "$cluster_config")
+    local app_vip=$(yq eval '.app_vips[0]' "$cluster_config")
+
+    # Validate
+    if [ -z "$cluster_name" ] || [ -z "$base_domain" ] || [ -z "$api_vip" ] || [ -z "$app_vip" ]; then
+        echo "Error: Missing required cluster configuration"
+        return 1
+    fi
+
+    echo "Cluster: ${cluster_name}.${base_domain}"
+    echo "API VIP: ${api_vip}"
+    echo "App VIP: ${app_vip}"
+
+    # Add API DNS entries
+    echo "Adding API DNS entries..."
+    sudo virsh net-update default add dns-host \
+      "<host ip='${api_vip}'><hostname>api.${cluster_name}.${base_domain}</hostname><hostname>api-int.${cluster_name}.${base_domain}</hostname></host>" \
+      --live --config 2>&1 | grep -v "already exists" || true
+
+    # Add common app hostnames (libvirt dnsmasq doesn't support wildcards)
+    echo "Adding application DNS entries..."
+    local apps="console-openshift-console oauth-openshift grafana-openshift-monitoring prometheus-k8s-openshift-monitoring alertmanager-main-openshift-monitoring thanos-querier-openshift-monitoring downloads-openshift-console"
+    for app in $apps; do
+        sudo virsh net-update default add dns-host \
+          "<host ip='${app_vip}'><hostname>${app}.apps.${cluster_name}.${base_domain}</hostname></host>" \
+          --live --config 2>&1 | grep -v "already exists" || true
+    done
+
+    echo "DNS entries configured successfully"
+    echo "Test with: dig @192.168.122.1 api.${cluster_name}.${base_domain}"
+    echo ""
+}
+
+# Function to configure host DNS to use libvirt
+configure_host_dns() {
+    echo "============================================================="
+    echo "Configuring host to use libvirt DNS..."
+    echo "============================================================="
+
+    # Detect primary connection (exclude loopback and libvirt bridges)
+    local primary_conn=$(nmcli -t -f NAME,DEVICE connection show --active | grep -v "lo\|virbr" | head -1 | cut -d: -f1)
+
+    if [ -z "$primary_conn" ]; then
+        echo "Warning: Could not detect primary network connection"
+        return 1
+    fi
+
+    echo "Primary connection: $primary_conn"
+
+    # Get current DNS servers
+    local current_dns=$(nmcli -g ipv4.dns connection show "$primary_conn" | tr ',' ' ')
+
+    # Check if 192.168.122.1 is already first
+    if echo "$current_dns" | grep -q "^192.168.122.1"; then
+        echo "Host DNS already configured with libvirt DNS as primary"
+        return 0
+    fi
+
+    # Build new DNS list: 192.168.122.1 first, then existing servers
+    local new_dns="192.168.122.1"
+    for dns in $current_dns; do
+        if [ "$dns" != "192.168.122.1" ]; then
+            new_dns="$new_dns $dns"
+        fi
+    done
+
+    echo "Setting DNS servers: $new_dns"
+
+    # Update connection
+    sudo nmcli connection modify "$primary_conn" ipv4.dns "$new_dns"
+    sudo nmcli connection up "$primary_conn"
+
+    echo "Host DNS configured successfully"
+    echo "  Primary: 192.168.122.1 (libvirt - cluster DNS)"
+    echo "  Backup: ${current_dns// /, } (upstream)"
+    echo ""
+}
+
 # Extract node names using yq
 node_names=$(yq e '.nodes[].hostname' "$yaml_file")
 
@@ -158,6 +247,33 @@ EOF
     fi
 fi
 
+# Configure DNS entries for the cluster
+echo "============================================================="
+echo "Setting up DNS configuration..."
+echo "============================================================="
+
+# Determine cluster config file path
+CLUSTER_CONFIG_FILE="${yaml_file%/nodes.yml}/cluster.yml"
+if [ ! -f "$CLUSTER_CONFIG_FILE" ]; then
+    # Try alternate path format
+    CLUSTER_CONFIG_FILE="examples/$(basename $(dirname ${yaml_file}))/cluster.yml"
+fi
+
+if [ -f "$CLUSTER_CONFIG_FILE" ]; then
+    echo "Using cluster config: $CLUSTER_CONFIG_FILE"
+
+    # Configure libvirt DNS entries
+    configure_cluster_dns "$CLUSTER_CONFIG_FILE" || echo "Warning: DNS configuration failed but continuing deployment"
+
+    # Configure host to use libvirt DNS
+    configure_host_dns || echo "Warning: Host DNS configuration failed but continuing deployment"
+else
+    echo "Warning: cluster.yml not found at $CLUSTER_CONFIG_FILE, skipping DNS configuration"
+fi
+
+echo "============================================================="
+echo ""
+
 # Loop through each node name
 for node_name in $node_names; do
     echo "Node Name: $node_name"
@@ -212,7 +328,7 @@ for node_name in $node_names; do
 done
 
 # Verify the installation if Redfish is enabled
-if [ "$USE_REDFISH" == true]; then
+if [ "$USE_REDFISH" == true ]; then
     echo "Verifying Redfish registration..."
     registered_systems=$(curl -s http://localhost:8000/redfish/v1/Systems)
     echo "Registered systems:"

--- a/hack/destroy-on-kvm.sh
+++ b/hack/destroy-on-kvm.sh
@@ -9,10 +9,79 @@ yaml_file=$1
 
 LIBVIRT_VM_PATH="/var/lib/libvirt/images"
 
+# Function to remove DNS entries from libvirt network
+remove_cluster_dns() {
+    local cluster_config=$1
+
+    echo "============================================================="
+    echo "Removing DNS entries from libvirt network..."
+    echo "============================================================="
+
+    local cluster_name=$(yq eval '.cluster_name' "$cluster_config" 2>/dev/null)
+    local base_domain=$(yq eval '.base_domain' "$cluster_config" 2>/dev/null)
+    local api_vip=$(yq eval '.api_vips[0]' "$cluster_config" 2>/dev/null)
+    local app_vip=$(yq eval '.app_vips[0]' "$cluster_config" 2>/dev/null)
+
+    if [ -z "$cluster_name" ] || [ -z "$base_domain" ]; then
+        echo "Warning: Could not parse cluster config for DNS cleanup"
+        return 0
+    fi
+
+    echo "Cluster: ${cluster_name}.${base_domain}"
+
+    # Remove API entries (need to specify IP for removal)
+    echo "Removing API DNS entries..."
+    if [ -n "$api_vip" ]; then
+        sudo virsh net-update default delete dns-host \
+          "<host ip='${api_vip}'><hostname>api.${cluster_name}.${base_domain}</hostname><hostname>api-int.${cluster_name}.${base_domain}</hostname></host>" \
+          --live --config 2>/dev/null || true
+    fi
+
+    # Remove app entries
+    echo "Removing application DNS entries..."
+    if [ -n "$app_vip" ]; then
+        local apps="console-openshift-console oauth-openshift grafana-openshift-monitoring prometheus-k8s-openshift-monitoring alertmanager-main-openshift-monitoring thanos-querier-openshift-monitoring downloads-openshift-console"
+        for app in $apps; do
+            sudo virsh net-update default delete dns-host \
+              "<host ip='${app_vip}'><hostname>${app}.apps.${cluster_name}.${base_domain}</hostname></host>" \
+              --live --config 2>/dev/null || true
+        done
+    fi
+
+    echo "DNS entries removed successfully"
+    echo ""
+}
+
 #########################################################
 ## Check to see if all the nodes have reported in
 
 echo -e "===== Deleting OpenShift Libvirt Infrastructure..."
+
+# Remove DNS entries first
+CLUSTER_CONFIG_FILE="${yaml_file%/nodes.yml}/cluster.yml"
+if [ ! -f "$CLUSTER_CONFIG_FILE" ]; then
+    # Try alternate path format
+    CLUSTER_CONFIG_FILE="examples/$(basename $(dirname ${yaml_file}))/cluster.yml"
+fi
+
+if [ -f "$CLUSTER_CONFIG_FILE" ]; then
+    echo "Using cluster config: $CLUSTER_CONFIG_FILE"
+    remove_cluster_dns "$CLUSTER_CONFIG_FILE"
+else
+    echo "Warning: cluster.yml not found, skipping DNS cleanup"
+fi
+
+# Parse cluster name for disk cleanup
+if [ -f "$CLUSTER_CONFIG_FILE" ]; then
+    CLUSTER_NAME=$(yq eval '.cluster_name' "$CLUSTER_CONFIG_FILE" 2>/dev/null)
+fi
+
+# Default to ocp4 if not found
+if [ -z "$CLUSTER_NAME" ]; then
+    CLUSTER_NAME="ocp4"
+fi
+
+echo "Using cluster name: $CLUSTER_NAME"
 
 node_names=$(yq e '.nodes[].hostname' "$yaml_file")
 
@@ -25,14 +94,26 @@ echo "Node Name: $node_name"
   VIRSH_VM=$(sudo virsh list --all | grep ${node_name} || true);
   if [[ ! -z "${VIRSH_VM}" ]]; then
     echo "  Deleting VM ${node_name} ..."
-    sudo virsh shutdown ${node_name} || true
+    sudo virsh destroy ${node_name} 2>/dev/null || true
     sudo virsh undefine ${node_name} || true
   fi
 
-  ## See if the disk image exists
-  if [[ -f "${LIBVIRT_VM_PATH}/${node_name}.qcow2" ]]; then
-    echo "  Deleting disk for VM $(_jq '.name') at ${LIBVIRT_VM_PATH}/${node_name}.qcow2 ..."
-    sudo rm ${LIBVIRT_VM_PATH}/${node_name}.qcow2 || true
+  ## See if the disk image exists (with cluster name prefix)
+  if [[ -f "${LIBVIRT_VM_PATH}/${CLUSTER_NAME}-${node_name}.qcow2" ]]; then
+    echo "  Deleting disk for VM ${node_name} at ${LIBVIRT_VM_PATH}/${CLUSTER_NAME}-${node_name}.qcow2 ..."
+    sudo rm ${LIBVIRT_VM_PATH}/${CLUSTER_NAME}-${node_name}.qcow2 || true
+  fi
+
+  ## Remove ODF disk if it exists
+  if [[ -f "${LIBVIRT_VM_PATH}/${CLUSTER_NAME}-${node_name}-odf.qcow2" ]]; then
+    echo "  Deleting ODF disk for VM ${node_name} ..."
+    sudo rm ${LIBVIRT_VM_PATH}/${CLUSTER_NAME}-${node_name}-odf.qcow2 || true
   fi
 
 done
+
+# Remove agent ISO
+if [[ -f "${LIBVIRT_VM_PATH}/agent.x86_64.iso" ]]; then
+    echo "Removing agent ISO..."
+    sudo rm ${LIBVIRT_VM_PATH}/agent.x86_64.iso || true
+fi

--- a/hack/vyos-router.sh
+++ b/hack/vyos-router.sh
@@ -80,11 +80,11 @@ EOF"
 function create(){
     export ip_address="${DNS_FORWARDER}"
     create_livirt_networks
-    # Vyos nightly builds 
+    # Vyos nightly builds
     # https://github.com/vyos/vyos-rolling-nightly-builds/releases
-    VYOS_VERSION=1.5-rolling-202502170007
+    VYOS_VERSION=2026.03.16-0030-rolling
     ISO_LOC=https://github.com/vyos/vyos-nightly-build/releases/download/${VYOS_VERSION}/vyos-${VYOS_VERSION}-generic-amd64.iso
-    if [ ! -f $HOME/vyos-${VYOS_VERSION}-amd64.iso ];
+    if [ ! -f $HOME/vyos-${VYOS_VERSION}-generic-amd64.iso ];
     then
         cd $HOME
         curl -OL $ISO_LOC

--- a/hack/vyos-router.sh
+++ b/hack/vyos-router.sh
@@ -76,18 +76,9 @@ EOF"
     done
 }
 
-function check_freeipa() {
-    export vm_name="freeipa"
-    export ip_address=$(sudo kcli info vm "$vm_name" "$vm_name" | grep ip: | awk '{print $2}' | head -1)
-    if [ -z "$ip_address" ]; then
-        echo "Error: FreeIPA VM IP address not found"
-        exit 1
-    fi
-    echo "FreeIPA IP address: $ip_address"
-}
 
 function create(){
-    check_freeipa
+    export ip_address="${DNS_FORWARDER}"
     create_livirt_networks
     # Vyos nightly builds 
     # https://github.com/vyos/vyos-rolling-nightly-builds/releases


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive lightweight DNS solution that replaces the FreeIPA dependency with dnsmasq and automates DNS configuration for OpenShift deployments.

### Key Changes

- **Automated DNS Configuration**: Deploy and destroy scripts now automatically configure DNS entries in libvirt's dnsmasq for cluster API and app routes
- **Host DNS Integration**: Automatically configures the deployment host to use libvirt DNS (192.168.122.1) as primary with upstream fallback
- **Lightweight DNS Solution**: Migrated from FreeIPA VM to dnsmasq running in VyOS router, reducing resource overhead
- **Improved Cleanup**: Fixed bugs in destroy script for proper disk image removal and DNS cleanup
- **Enhanced Documentation**: Added comprehensive DNS setup guides and automation documentation

### Technical Details

**DNS Automation (`hack/deploy-on-kvm.sh`)**:
- Automatically adds DNS entries to libvirt dnsmasq during deployment
- Configures API endpoints: `api.<cluster>.<domain>` and `api-int.<cluster>.<domain>`
- Pre-configures common app routes (console, oauth, monitoring, etc.)
- Configures host to use libvirt DNS as primary with upstream DNS as backup
- Graceful error handling - deployment continues even if DNS configuration fails

**DNS Cleanup (`hack/destroy-on-kvm.sh`)**:
- Automatically removes DNS entries when cluster is destroyed
- Fixed disk image removal to use proper cluster name prefix
- Removes ODF disks and agent ISO
- Uses `virsh destroy` instead of `shutdown` for faster cleanup

**Lightweight DNS Infrastructure**:
- Replaced FreeIPA VM with dnsmasq in VyOS router
- Reduced resource requirements (no separate DNS VM needed)
- Simplified DNS management scripts
- VyOS router updated to latest ISO

### Benefits

✅ No manual DNS configuration required
✅ `oc` commands work without `--server` or `--insecure-skip-tls-verify` flags
✅ Multi-cluster support - multiple clusters can coexist with different DNS entries
✅ Persistent configuration survives host reboots
✅ Clean teardown - DNS entries automatically removed
✅ Reduced infrastructure overhead (no FreeIPA VM)
✅ Graceful fallback - upstream DNS still works for internet resolution

### Files Modified

- `hack/deploy-on-kvm.sh` - Added DNS automation functions
- `hack/destroy-on-kvm.sh` - Added DNS cleanup and fixed disk removal bugs
- `hack/vyos-router.sh` - Updated to use latest VyOS ISO
- `hack/configure-dnsmasq-entries.sh` - New script for dnsmasq configuration
- `hack/setup-dnsmasq.sh` - New helper script for dnsmasq setup
- `DNS_AUTOMATION.md` - Comprehensive automation documentation
- `docs/dns-setup.md` - DNS setup guide
- `docs/adr/0011-identity-management-integration.md` - Updated architecture decision record

### Testing

- ✅ Tested full deployment workflow with automated DNS configuration
- ✅ Verified DNS entries added to libvirt during deployment
- ✅ Verified host DNS configured to use libvirt as primary
- ✅ Confirmed cluster access works without workarounds
- ✅ Tested cleanup - DNS entries and disk images properly removed
- ✅ Verified internet DNS still works (upstream fallback)

### Known Limitations

- Libvirt dnsmasq doesn't support wildcard DNS (`*.apps.ocp4.example.com`)
  - Workaround: Pre-configured common app routes added automatically
- Requires sudo access for `virsh net-update` and `nmcli` commands
- Host DNS configuration requires NetworkManager

See `DNS_AUTOMATION.md` for complete documentation, verification steps, and troubleshooting guide.